### PR TITLE
Disable preview at gyazo.com

### DIFF
--- a/src/common/content/content.js
+++ b/src/common/content/content.js
@@ -611,4 +611,7 @@
   })
 })()
 
-require('./expander')
+// Disable expander at gyazo.com
+if (!(/^(.+\.)?gyazo\.com$/).test(window.location.host)) {
+  require('./expander')
+}


### PR DESCRIPTION
In most cases, preview at gyazo.com is useless. 
This change disables preview at `*.gyazo.com`.
