### PR TITLE
Disable some feature doesn't work well on Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "Gyazo-Extension",
   "version": "2.4.1",
   "dependencies": {
+    "bowser": "^1.3.0",
     "delegate": "^3.0.0",
     "dom-css": "^2.0.0",
     "jquery": "^2.1.4",

--- a/src/common/content/content.js
+++ b/src/common/content/content.js
@@ -3,6 +3,7 @@
     return
   }
   window.__embededGyazoContentJS = true
+  const browser = require('bowser')
   const storage = require('../libs/storageSwitcher')
   const ESC_KEY_CODE = 27
   const JACKUP_HEIGHT = 30
@@ -672,6 +673,7 @@
     }
     return true
   })
-
+  // XXX: Firefox can't embed moz-extension:// file in content
+  if (browser.firefox) return
   require('./expander')
 })()

--- a/src/common/libs/UploadNotification.js
+++ b/src/common/libs/UploadNotification.js
@@ -1,3 +1,5 @@
+const browser = require('bowser')
+
 module.exports = class UploadNotification {
   constructor (tabId) {
     this.tabId = tabId
@@ -10,7 +12,7 @@ module.exports = class UploadNotification {
   finish (imagePageUrl, imageDataUrl, callback) {
     this.update({
       title: chrome.i18n.getMessage('uploadingFinishTitle'),
-      message: chrome.i18n.getMessage('uploadingFinishMessage'),
+      message: browser.firefox ? '' : chrome.i18n.getMessage('uploadingFinishMessage'),
       imagePageUrl: imagePageUrl,
       imageUrl: imageDataUrl,
       isFinish: true

--- a/src/normal/index.js
+++ b/src/normal/index.js
@@ -1,4 +1,5 @@
 const $ = require('jquery')
+const browser = require('bowser')
 const UploadNotification = require('../common/libs/UploadNotification')
 const saveToClipboard = require('../common/libs/saveToClipboard')
 const canvasUtils = require('../common/libs/canvasUtils')
@@ -141,13 +142,16 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo) {
   }
 })
 
-chrome.contextMenus.onClicked.addListener(onClickHandler)
+// XXX: Buggy contextMenus on Firefox < v49
+if (browser.firefox && browser.version >= 49) {
+  chrome.contextMenus.onClicked.addListener(onClickHandler)
 
-chrome.contextMenus.create({
-  title: chrome.i18n.getMessage('contextMenuImage'),
-  id: 'gyazoIt',
-  contexts: ['image']
-})
+  chrome.contextMenus.create({
+    title: chrome.i18n.getMessage('contextMenuImage'),
+    id: 'gyazoIt',
+    contexts: ['image']
+  })
+}
 
 chrome.browserAction.onClicked.addListener(function (tab) {
   if (tab.url.match(/chrome\.google\.com\/webstore\//)) {


### PR DESCRIPTION
Disable features

- context menu `Gyazo it`
  - context menu is broken on Firefox Webextension
- doesn't copy because Firefox doesn't permit clipboard access
- Disable Preview