### PR TITLE
Overwrite absolute with !important

### DIFF
--- a/src/common/content/content.js
+++ b/src/common/content/content.js
@@ -28,10 +28,10 @@
 
   function changeFixedElementToAbsolute () {
     Array.prototype.slice.apply(document.querySelectorAll('*')).filter(function (item) {
-      return (window.window.getComputedStyle(item).position === 'fixed')
+      return (window.getComputedStyle(item).position === 'fixed')
     }).forEach(function (item) {
       item.classList.add('gyazo-whole-capture-onetime-absolute')
-      item.style.position = 'absolute'
+      item.style.setProperty('position', 'absolute', 'important')
     })
   }
 


### PR DESCRIPTION
If element's `position` property is `fixed !important`, it cannot overwrite `absolute`. It should add `!important`