### PR TITLE
Change add destination of mouseover event listener

### DIFF
--- a/src/common/content/expander/index.js
+++ b/src/common/content/expander/index.js
@@ -62,7 +62,7 @@ function createImagePreview ({ url, boxStyle }) {
 }
 
 let previewIsShown = false
-delegate(document.body, 'a', 'mouseover', (event) => {
+delegate(document, 'a', 'mouseover', (event) => {
   if (previewIsShown) return
 
   const element = event.target


### PR DESCRIPTION
Failure to add an event if there is no body element at loading.

Changed `document.body` to `document`.