### PR TITLE
Paste support on website (ex: github.com)

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -1,6 +1,7 @@
 import browserInfo from 'bowser'
 import MessageListener from '../libs/MessageListener'
 import expander from './expander'
+import pasteUtil from './paste'
 import notification from './notification'
 import insertMenu from './insertMenu'
 import {changeFixedElementToAbsolute} from './actions'
@@ -25,4 +26,6 @@ import {changeFixedElementToAbsolute} from './actions'
     !browserInfo.firefox && // XXX: Firefox can't embed moz-extension:// file in content
     !(/^(.+\.)?gyazo\.com$/).test(window.location.host)  // Prevent showing preview on gyazo.com
   ) expander()
+
+  pasteUtil()
 })()

--- a/src/content/paste/index.js
+++ b/src/content/paste/index.js
@@ -1,27 +1,27 @@
 import storage from '../../libs/storageSwitcher'
-import defaultWebsitesInfo from './websitesInfo'
+import defaultWebsites from './websites'
 
 export default async () => {
   let usersSettings
   try {
     usersSettings = (await storage.get({
-      pasteWebsitesInfo: [],
+      pasteWebsites: [],
       pasteSupport: true
     }))
   } catch (e) {}
 
   if (!usersSettings.pasteSupport) return
 
-  const usersWebsiteSettings = usersSettings ? usersSettings.pasteWebsitesInfo : []
+  const usersWebsiteSettings = usersSettings ? usersSettings.pasteWebsites : []
 
-  const websitesInfo = usersWebsiteSettings.concat(defaultWebsitesInfo)
+  const websites = usersWebsiteSettings.concat(defaultWebsites)
 
-  const websiteInfo = websitesInfo.find((e) => e && e.host.test(location.hostname))
-  if (!websiteInfo) return
+  const website = websites.find((e) => e && e.host.test(location.hostname))
+  if (!website) return
 
   document.addEventListener('paste', (event) => {
     const element = event.target
-    if (!element.classList.contains(websiteInfo.className)) return
+    if (!element.classList.contains(website.className)) return
 
     const pasteText = event.clipboardData.getData('text/plain')
 

--- a/src/content/paste/index.js
+++ b/src/content/paste/index.js
@@ -4,8 +4,14 @@ import defaultWebsitesInfo from './websitesInfo'
 export default async () => {
   let usersSettings
   try {
-    usersSettings = (await storage.get({pasteWebsitesInfo: []}))
+    usersSettings = (await storage.get({
+      pasteWebsitesInfo: [],
+      pasteSupport: true
+    }))
   } catch (e) {}
+
+  if (!usersSettings.pasteSupport) return
+
   const usersWebsiteSettings = usersSettings ? usersSettings.pasteWebsitesInfo : []
 
   const websitesInfo = usersWebsiteSettings.concat(defaultWebsitesInfo)

--- a/src/content/paste/index.js
+++ b/src/content/paste/index.js
@@ -2,7 +2,7 @@ import storage from '../../libs/storageSwitcher'
 import defaultWebsites from './websites'
 
 export default async () => {
-  let usersSettings
+  let usersSettings = {}
   try {
     usersSettings = (await storage.get({
       pasteWebsites: [],
@@ -16,7 +16,7 @@ export default async () => {
 
   const websites = usersWebsiteSettings.concat(defaultWebsites)
 
-  const website = websites.some((e) => e && e.host.test(location.hostname))
+  const website = websites.find((e) => e && e.host.test(location.hostname))
   if (!website) return
 
   document.addEventListener('paste', (event) => {

--- a/src/content/paste/index.js
+++ b/src/content/paste/index.js
@@ -1,0 +1,30 @@
+import storage from '../../libs/storageSwitcher'
+import defaultWebsitesInfo from './websitesInfo'
+
+export default async () => {
+  let usersSettings
+  try {
+    usersSettings = (await storage.get({pasteWebsitesInfo: []}))
+  } catch (e) {}
+  const usersWebsiteSettings = usersSettings ? usersSettings.pasteWebsitesInfo : []
+
+  const websitesInfo = usersWebsiteSettings.concat(defaultWebsitesInfo)
+
+  const websiteInfo = websitesInfo.find((e) => e && e.host.test(location.hostname))
+  if (!websiteInfo) return
+
+  document.addEventListener('paste', (event) => {
+    const element = event.target
+    if (!element.classList.contains(websiteInfo.className)) return
+
+    const pasteText = event.clipboardData.getData('text/plain')
+
+    if (!pasteText.match(/^https?:\/\/.*?.?gyazo\.com\/[a-z0-9]{32}$/)) return
+    event.preventDefault()
+
+    const mdText = `[![${pasteText}](${pasteText}/raw)](${pasteText})`
+    const value = element.value
+    const replacedText = value.substr(0, element.selectionStart) + mdText + value.substr(element.selectionEnd, value.length)
+    element.value = replacedText
+  })
+}

--- a/src/content/paste/index.js
+++ b/src/content/paste/index.js
@@ -16,12 +16,19 @@ export default async () => {
 
   const websites = usersWebsiteSettings.concat(defaultWebsites)
 
-  const website = websites.find((e) => e && e.host.test(location.hostname))
+  const website = websites.some((e) => e && e.host.test(location.hostname))
   if (!website) return
 
   document.addEventListener('paste', (event) => {
     const element = event.target
-    if (!element.classList.contains(website.className)) return
+    if (typeof website.className === 'string') {
+      if (!element.classList.contains(website.className)) return
+    } else if (Array.isArray(website.className)) {
+      const containsEnabledClassName = website.className.some((className) => element.classList.contains(className))
+      if (!containsEnabledClassName) return
+    } else {
+      return
+    }
 
     const pasteText = event.clipboardData.getData('text/plain')
 

--- a/src/content/paste/websites.js
+++ b/src/content/paste/websites.js
@@ -2,6 +2,10 @@ const websites = [
   {
     host: /^github\.com$/,
     className: 'comment-form-textarea'
+  },
+  {
+    host: /qiita\.com$/,
+    className: ['editorMarkdown_textarea', 'commentForm_textarea']
   }
 ]
 export default websites

--- a/src/content/paste/websites.js
+++ b/src/content/paste/websites.js
@@ -1,6 +1,6 @@
 const websites = [
   {
-    host: /^github\.com/,
+    host: /^github\.com$/,
     className: 'comment-form-textarea'
   }
 ]

--- a/src/content/paste/websitesInfo.js
+++ b/src/content/paste/websitesInfo.js
@@ -1,0 +1,7 @@
+const websites = [
+  {
+    host: /^github\.com/,
+    className: 'comment-form-textarea'
+  }
+]
+export default websites

--- a/src/statics/_locales/en/messages.json
+++ b/src/statics/_locales/en/messages.json
@@ -34,5 +34,8 @@
   },
   "myImage": {
     "message": "Home"
+  },
+  "pasteSupportSettingText": {
+    "message": "Replace Gyazo's URL to markdown style when it's pasted."
   }
 }

--- a/src/statics/_locales/ja/messages.json
+++ b/src/statics/_locales/ja/messages.json
@@ -34,5 +34,8 @@
   },
   "myImage": {
     "message": "ホーム"
+  },
+  "pasteSupportSettingText": {
+    "message": "GyazoのURLが貼り付けられたら、markdown形式に置き換える"
   }
 }

--- a/src/statics/option/option.js
+++ b/src/statics/option/option.js
@@ -2,10 +2,13 @@ import storage from '../../libs/storageSwitcher'
 
 let selector = document.getElementById('selector')
 let delaySelector = document.getElementById('delay')
-storage.get({behavior: 'element', delay: 1})
+let pasteSupportSetting = document.getElementById('pasteSupportSetting')
+
+storage.get({behavior: 'element', delay: 1, pasteSupport: true})
   .then((item) => {
     selector.value = item.behavior
     delaySelector.value = item.delay
+    pasteSupportSetting.checked = item.pasteSupport
   })
 document.getElementById('element').textContent = chrome.i18n.getMessage('selectElement')
 document.getElementById('area').textContent = chrome.i18n.getMessage('selectArea')
@@ -28,4 +31,8 @@ delaySelector.addEventListener('change', function (event) {
         document.querySelector('.scroll-delay-save').textContent = ''
       }, 2500)
     })
+})
+
+pasteSupportSetting.addEventListener('change', (event) => {
+  storage.set({pasteSupport: pasteSupportSetting.checked})
 })

--- a/src/statics/option/option.js
+++ b/src/statics/option/option.js
@@ -12,6 +12,7 @@ storage.get({behavior: 'element', delay: 1, pasteSupport: true})
   })
 document.getElementById('element').textContent = chrome.i18n.getMessage('selectElement')
 document.getElementById('area').textContent = chrome.i18n.getMessage('selectArea')
+document.getElementById('pasteSupportSettingText').textContent = chrome.i18n.getMessage('pasteSupportSettingText')
 
 selector.addEventListener('change', function (event) {
   storage.set({behavior: event.target.value})

--- a/src/statics/option/options.html
+++ b/src/statics/option/options.html
@@ -30,7 +30,7 @@
   <br /><br />
 
   <label>
-    <input id='pasteSupportSetting' type='checkbox' />Enable replace markdown style from gyazo's URL.
+    <input id='pasteSupportSetting' type='checkbox' /><span id='pasteSupportSettingText'></span>
   </label>
 
   <script src="/option.js"></script>

--- a/src/statics/option/options.html
+++ b/src/statics/option/options.html
@@ -26,6 +26,13 @@
   <span style='font-size: 12px;'>Long</span>
   <br />
   <span style='font-size: 12px'>Please set longer if your image is broken.</span>
+
+  <br /><br />
+
+  <label>
+    <input id='pasteSupportSetting' type='checkbox' />Enable replace markdown style from gyazo's URL.
+  </label>
+
   <script src="/option.js"></script>
 </body>
 </html>


### PR DESCRIPTION
When you paste Gyazo's URL it convert to markdown style.

For example, you paste `https://gyazo.com/a9c009b7e9ba6d000604b05ff00684c7` on github's issue page, then pasted text will be `[![https://gyazo.com/a9c009b7e9ba6d000604b05ff00684c7](https://gyazo.com/a9c009b7e9ba6d000604b05ff00684c7/raw)](https://gyazo.com/a9c009b7e9ba6d000604b05ff00684c7)`

You can enable/disable on option page