### PR TITLE
make captured area rect opacity 0

### DIFF
--- a/src/content/actions/gyazoCaptureSelectedArea.js
+++ b/src/content/actions/gyazoCaptureSelectedArea.js
@@ -101,6 +101,7 @@ export default (request) => {
       cancelGyazo()
       return false
     }
+    layer.style.opacity = 0
     data.x = rect.left + window.scrollX
     data.y = rect.top + window.scrollY
     data.t = document.title

--- a/src/content/actions/gyazoSelectElm.js
+++ b/src/content/actions/gyazoSelectElm.js
@@ -74,6 +74,7 @@ export default async (request) => {
   const clickElement = function (event) {
     event.stopPropagation()
     event.preventDefault()
+    layer.style.opacity = 0
     document.body.classList.remove('gyazo-select-element-mode')
     allElms.forEach(function (item) {
       if (item.classList.contains('gyazo-select-element-cursor-overwrite')) {


### PR DESCRIPTION
When Browser fps is slow, capture contains rect color.
Change css opacity value is more quick than document.removeChild. So we
believe it will solve problem