### PR TITLE
prevent apply function on click default selected button

### DIFF
--- a/src/content/insertMenu.js
+++ b/src/content/insertMenu.js
@@ -89,12 +89,14 @@ export default async (request, sender, sendResponse) => {
     gyazoCaptureSelectedArea(request, sender, sendResponse)
   }
   selectAreaBtn.addEventListener('click', function () {
+    if (behavior === 'area') return
     hideMenu()
     window.requestAnimationFrame(function () {
       gyazoCaptureSelectedArea(request, sender, sendResponse)
     })
   })
   selectElementBtn.addEventListener('click', function () {
+    if (behavior === 'element') return
     hideMenu()
     window.requestAnimationFrame(function () {
       gyazoSelectElm(request, sender, sendResponse)


### PR DESCRIPTION
## CASE

0. Set default bahaivor `element` on option.
1. Start Gyazo Extension and open capture-type menu.
2. Click `Element` button.
3. Select any element on page.
4. Upload image twice