### PR TITLE
wait for delay-timing and force reflow before capture

### DIFF
--- a/src/libs/gyazoCaptureWithSize.js
+++ b/src/libs/gyazoCaptureWithSize.js
@@ -142,5 +142,5 @@ export default (request, sender, sendResponse) => {
       capture(scrollHeight, scrollWidth, _lastImageBottom, _lastImageRight, data)
     })
   }
-  capture()
+  waitForDelay(capture)
 }

--- a/src/libs/waitForDelay.js
+++ b/src/libs/waitForDelay.js
@@ -1,7 +1,14 @@
+import thenChrome from 'then-chrome'
 import storage from './storageSwitcher'
 const DELAY_TIMES = [0, 200, 400, 700, 1000]
 
-export default (callback) => {
+export default async (callback) => {
+  // Force reflow on browser content
+  // c.f. https://stackoverflow.com/questions/21664940
+  const currentTab = (await thenChrome.tabs.query({currentWindow: true, active: true}))[0]
+  await thenChrome.tabs.executeScript(currentTab.id, {
+    code: 'console.log(document.body.offsetHeight)'
+  })
   storage.get({delay: 1})
     .then((item) => {
       let delay = DELAY_TIMES[item.delay]


### PR DESCRIPTION
on environment with high Latency display update(ex: Chrome on 4K display) , captures will contain blue/gray layer or menu element.

This will wait for some milli sec (set by option) and then force update(reflow) by `document.body.offsetHeight` (cf: https://stackoverflow.com/questions/21664940).

Maybe this p-r make it more stable.