### PR TITLE
Fix the bug misaligning position of selection range.

### DIFF
--- a/src/content/actions/gyazoCaptureSelectedArea.js
+++ b/src/content/actions/gyazoCaptureSelectedArea.js
@@ -33,7 +33,7 @@ export default (request) => {
   }
   selectionElm.styleUpdate({
     background: 'rgba(92, 92, 92, 0.3)',
-    position: 'absolute'
+    position: 'fixed'
   })
   const cancelGyazo = function () {
     if (!(layer.parentNode && jackup.element.parentNode)) return
@@ -79,7 +79,7 @@ export default (request) => {
       width: (Math.abs(e.pageX - startX) - 1) + 'px',
       height: (Math.abs(e.pageY - startY) - 1) + 'px',
       left: Math.min(e.pageX, startX) + 'px',
-      top: Math.min(e.pageY, startY) + 'px'
+      top: Math.min(e.pageY, startY) - window.scrollY + 'px'
     })
   }
   const mouseupHandler = function (e) {


### PR DESCRIPTION
## About

- When you select range of capture by extension, its align goes wrong position.
- It occurs on the page which includes `position: fixed` element.
  - ex: https://www.msn.com/en-in/money/personalfinance/good-news-sbi-home-auto-loan-interest-rates-cut-set-to-be-effective-from-nov-1/ar-AAul5F8

## Check

- I checked on Chrome & Firefox
- cannot check on MS Edge, it occurs another error `IndexSizeError`

## Screenshot

### Before

[![https://gyazo.com/4987f82e5f98fb4194e756d6bba9b7f5](https://i.gyazo.com/4987f82e5f98fb4194e756d6bba9b7f5.gif)](https://gyazo.com/4987f82e5f98fb4194e756d6bba9b7f5)

### After

[![https://gyazo.com/e4923dc661bebc98669a1f9273c6919d](https://i.gyazo.com/e4923dc661bebc98669a1f9273c6919d.gif)](https://gyazo.com/e4923dc661bebc98669a1f9273c6919d)