### PR TITLE
overwrite minHeight and maxHeight

### DIFF
--- a/src/libs/jackupElement.js
+++ b/src/libs/jackupElement.js
@@ -14,7 +14,10 @@ export default class JackupElement {
     const html = document.querySelector('html')
     const body = document.querySelector('body')
 
-    this.element.style.height = (window.innerHeight + JACKUP_MARGIN) + 'px'
+    const cssVal = (window.innerHeight + JACKUP_MARGIN) + 'px'
+    this.element.style.height = cssVal
+    this.element.style.maxHeight = cssVal
+    this.element.style.minHeight = cssVal
 
     const htmlHeight = window.getComputedStyle(html).getPropertyValue('height')
     const bodyHeight = window.getComputedStyle(body).getPropertyValue('height')


### PR DESCRIPTION
It prevent to capture on https://www.msn.com/ja-jp/ , https://gyazo.com/pro and so on...

These websites set min-height or max-height for div so This pr will overwrite their value