### PR TITLE
Apply display:block to gyazo-menu.

### DIFF
--- a/src/statics/menu.css
+++ b/src/statics/menu.css
@@ -19,6 +19,7 @@ body.gyazo-select-element-mode *:not(.gyazo-crop-select-element):not(.gyazo-menu
 }
 
 .gyazo-menu {
+  display: block !important;
   box-sizing: border-box !important;
   position: fixed !important;
   right: 0 !important;


### PR DESCRIPTION
## About

- Add `display:block` to `div.gyazo-menu`.
- To layout the menu correctly, even though div tags in a web page have different CSS `display` style.
- As an example, you can find this problem on a single photo page on Instagram.com.

## Screenshots

### Before

[![Screenshot from Gyazo](https://gyazo.com/66eaa77bb8d480f956f7008e4a19dd82/raw)](https://gyazo.com/66eaa77bb8d480f956f7008e4a19dd82)

### After

[![Screenshot from Gyazo](https://gyazo.com/3c64c7d097ca14748b6c5a8121190a1a/raw)](https://gyazo.com/3c64c7d097ca14748b6c5a8121190a1a)