### PR TITLE
remove <all_urls> permission 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Gyazo-Extension",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "dependencies": {
     "bowser": "^1.3.0",
     "chrome-browser-object-polyfill": "^0.2.2",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,7 +4,8 @@
   "short_name": "Gyazo",
   "author": "Nota inc.",
   "permissions": [
-    "<all_urls>",
+    "https://upload.gyazo.com/*",
+    "https://gyazo.com/*",
     "activeTab",
     "contextMenus",
     "tabs",


### PR DESCRIPTION
Google says `A permission is either one of a list of known strings, such as "activeTab", or a match pattern giving access to one or more hosts.` on dashboard so we can remove <all_urls> and it's ok activeTab only