### PR TITLE
Add <all_urls> permission to the manifest for chrome

### DIFF
--- a/src/manifests/chrome.json
+++ b/src/manifests/chrome.json
@@ -4,6 +4,7 @@
   "short_name": "Gyazo",
   "author": "Nota inc.",
   "permissions": [
+    "<all_urls>",
     "https://upload.gyazo.com/*",
     "https://gyazo.com/*",
     "https://i.gyazo.com/*",


### PR DESCRIPTION
## Probrem
Using Chrome Extension, Unable to capture pictures on some websites.
It's probably since #265 was merged(since version 3.1.0 ?).
Here is an example; In pixiv.net an error occurs due to a CORS policy.
```
// console of a background page
Access to XMLHttpRequest at 'https://i.pximg.net/***.jpg' from origin 'chrome-extension://plancmjpkcgbonmakhjeebjeggaenpmj' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```
To address this issue, add <all_urls> permission.

## Risk
[Gyazo Chrome Extensionの再公開について - Gyazo Blog](https://blogja.gyazo.com/entry/2020/07/29/173000)
I have read the article.
I'm wondering if `<all_urls>` permission has anything to do with Google's review process.
Changing permission may be a risk, but please consider it.